### PR TITLE
中華民國一百一十四年多三天放假

### DIFF
--- a/data/2025.json
+++ b/data/2025.json
@@ -1628,8 +1628,8 @@
   {
     "date": "20250929",
     "week": "一",
-    "isHoliday": false,
-    "description": ""
+    "isHoliday": true,
+    "description": "孔子誕辰紀念日補假,教師節補假"
   },
   {
     "date": "20250930",
@@ -1778,8 +1778,8 @@
   {
     "date": "20251024",
     "week": "五",
-    "isHoliday": false,
-    "description": ""
+    "isHoliday": true,
+    "description": "臺灣光復暨金門古寧頭大捷紀念日補假"
   },
   {
     "date": "20251025",
@@ -2150,8 +2150,8 @@
   {
     "date": "20251225",
     "week": "四",
-    "isHoliday": false,
-    "description": ""
+    "isHoliday": true,
+    "description": "行憲紀念日"
   },
   {
     "date": "20251226",


### PR DESCRIPTION
根據[行政院公告](https://www.dgpa.gov.tw/information?uid=30&pid=12572)，
1. 臺灣至今到2025年底會有三天新的國定假日。
2. 紀念日及節日之放假日逢例假日者，應予補假。
所以在資料中新增了三天新的假日，若為補假則在描述中紀念日及假日的後方備註「補假」兩字。若同一天適用於超過一種以上的紀念日及假日則以半形後號分隔。